### PR TITLE
Make ProfileImageUrl and UserId properties nullable

### DIFF
--- a/Flow Api/Data/ApplicationDbContext.cs
+++ b/Flow Api/Data/ApplicationDbContext.cs
@@ -24,78 +24,84 @@ namespace Flow_Api.Data
             public DbSet<UserOtp> UserOtps { get; set; }
             public DbSet<RefreshToken> RefreshTokens { get; set; }
 
-            protected override void OnModelCreating(ModelBuilder builder)
+        // In your Data/ApplicationDbContext.cs file
+
+        protected override void OnModelCreating(ModelBuilder builder)
+        {
+            base.OnModelCreating(builder);
+
+            // Configure ApplicationUser
+            builder.Entity<ApplicationUser>(entity =>
             {
-                base.OnModelCreating(builder);
+                entity.Property(u => u.FirstName).HasMaxLength(50);
+                entity.Property(u => u.LastName).HasMaxLength(50);
 
-                // Configure ApplicationUser
-                builder.Entity<ApplicationUser>(entity =>
-                {
-                    entity.Property(u => u.FirstName).HasMaxLength(50);
-                    entity.Property(u => u.LastName).HasMaxLength(50);
-                    entity.Property(u => u.ProfileImageUrl).HasMaxLength(255);
-                    entity.Property(u => u.IsActive).HasDefaultValue(true);
-                    entity.Property(u => u.CreatedDate).HasDefaultValueSql("NOW()");
-                });
+                // Add this line to explicitly make ProfileImageUrl optional/nullable
+                entity.Property(u => u.ProfileImageUrl).HasMaxLength(255).IsRequired(false);
 
-                // Configure ApplicationRole
-                builder.Entity<ApplicationRole>(entity =>
-                {
-                    entity.Property(r => r.Description).HasMaxLength(255);
-                });
+                entity.Property(u => u.IsActive).HasDefaultValue(true);
+                entity.Property(u => u.CreatedDate).HasDefaultValueSql("NOW()");
+            });
 
-                // Configure Permission
-                builder.Entity<Permission>(entity =>
-                {
-                    entity.HasKey(p => p.Id);
-                    entity.Property(p => p.Name).IsRequired().HasMaxLength(100);
-                    entity.Property(p => p.Description).HasMaxLength(255);
-                    entity.Property(p => p.Category).IsRequired().HasMaxLength(50);
-                    entity.Property(p => p.CreatedDate).HasDefaultValueSql("NOW()");
-                });
+            // Rest of your configuration remains the same...
+            // Configure ApplicationRole
+            builder.Entity<ApplicationRole>(entity =>
+            {
+                entity.Property(r => r.Description).HasMaxLength(255);
+            });
 
-                // Configure UserOtp
-                builder.Entity<UserOtp>(entity =>
-                {
-                    entity.HasKey(o => o.Id);
-                    entity.Property(o => o.OtpCode).IsRequired().HasMaxLength(6);
-                    entity.Property(o => o.OtpType).IsRequired();
-                    entity.Property(o => o.ExpiryDate).IsRequired();
-                    entity.Property(o => o.IsUsed).IsRequired().HasDefaultValue(false);
-                    entity.Property(o => o.CreatedDate).HasDefaultValueSql("NOW()");
-                    entity.HasOne<ApplicationUser>()
-                        .WithMany()
-                        .HasForeignKey(o => o.UserId)
-                        .OnDelete(DeleteBehavior.Cascade);
-                });
+            // Configure Permission
+            builder.Entity<Permission>(entity =>
+            {
+                entity.HasKey(p => p.Id);
+                entity.Property(p => p.Name).IsRequired().HasMaxLength(100);
+                entity.Property(p => p.Description).HasMaxLength(255);
+                entity.Property(p => p.Category).IsRequired().HasMaxLength(50);
+                entity.Property(p => p.CreatedDate).HasDefaultValueSql("NOW()");
+            });
 
-                // Configure RefreshToken
-                builder.Entity<RefreshToken>(entity =>
-                {
-                    entity.HasKey(r => r.Id);
-                    entity.Property(r => r.Token).IsRequired();
-                    entity.Property(r => r.JwtId).IsRequired();
-                    entity.Property(r => r.IsUsed).IsRequired().HasDefaultValue(false);
-                    entity.Property(r => r.IsRevoked).IsRequired().HasDefaultValue(false);
-                    entity.Property(r => r.IssuedAt).IsRequired();
-                    entity.Property(r => r.ExpiresAt).IsRequired();
-                    entity.Property(r => r.CreatedDate).HasDefaultValueSql("NOW()");
-                    entity.HasOne<ApplicationUser>()
-                        .WithMany()
-                        .HasForeignKey(r => r.UserId)
-                        .OnDelete(DeleteBehavior.Cascade);
+            // Configure UserOtp
+            builder.Entity<UserOtp>(entity =>
+            {
+                entity.HasKey(o => o.Id);
+                entity.Property(o => o.OtpCode).IsRequired().HasMaxLength(6);
+                entity.Property(o => o.OtpType).IsRequired();
+                entity.Property(o => o.ExpiryDate).IsRequired();
+                entity.Property(o => o.IsUsed).IsRequired().HasDefaultValue(false);
+                entity.Property(o => o.CreatedDate).HasDefaultValueSql("NOW()");
+                entity.HasOne<ApplicationUser>()
+                    .WithMany()
+                    .HasForeignKey(o => o.UserId)
+                    .OnDelete(DeleteBehavior.Cascade);
+            });
 
-                    // Add index for Token
-                    entity.HasIndex(r => r.Token).IsUnique();
-                });
+            // Configure RefreshToken
+            builder.Entity<RefreshToken>(entity =>
+            {
+                entity.HasKey(r => r.Id);
+                entity.Property(r => r.Token).IsRequired();
+                entity.Property(r => r.JwtId).IsRequired();
+                entity.Property(r => r.IsUsed).IsRequired().HasDefaultValue(false);
+                entity.Property(r => r.IsRevoked).IsRequired().HasDefaultValue(false);
+                entity.Property(r => r.IssuedAt).IsRequired();
+                entity.Property(r => r.ExpiresAt).IsRequired();
+                entity.Property(r => r.CreatedDate).HasDefaultValueSql("NOW()");
+                entity.HasOne<ApplicationUser>()
+                    .WithMany()
+                    .HasForeignKey(r => r.UserId)
+                    .OnDelete(DeleteBehavior.Cascade);
 
-                // Configure RolePermissions (many-to-many relationship)
-                builder.Entity<ApplicationRole>()
-                    .HasMany<ApplicationRoleClaim>()
-                    .WithOne()
-                    .HasForeignKey(rc => rc.RoleId)
-                    .IsRequired();
-            }
+                // Add index for Token
+                entity.HasIndex(r => r.Token).IsUnique();
+            });
+
+            // Configure RolePermissions (many-to-many relationship)
+            builder.Entity<ApplicationRole>()
+                .HasMany<ApplicationRoleClaim>()
+                .WithOne()
+                .HasForeignKey(rc => rc.RoleId)
+                .IsRequired();
+        }
     }
 
         // UserOtp entity

--- a/Flow Api/Data/Migrations/20250928072927_MakeProfileImageUrlNullable.Designer.cs
+++ b/Flow Api/Data/Migrations/20250928072927_MakeProfileImageUrlNullable.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Flow_Api.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Flow_Api.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250928072927_MakeProfileImageUrlNullable")]
+    partial class MakeProfileImageUrlNullable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Flow Api/Data/Migrations/20250928072927_MakeProfileImageUrlNullable.cs
+++ b/Flow Api/Data/Migrations/20250928072927_MakeProfileImageUrlNullable.cs
@@ -1,0 +1,76 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Flow_Api.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class MakeProfileImageUrlNullable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "UserId",
+                table: "UserOtps",
+                type: "text",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "text");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "UserId",
+                table: "RefreshTokens",
+                type: "text",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "text");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "ProfileImageUrl",
+                table: "AspNetUsers",
+                type: "character varying(255)",
+                maxLength: 255,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(255)",
+                oldMaxLength: 255);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "UserId",
+                table: "UserOtps",
+                type: "text",
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "text",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "UserId",
+                table: "RefreshTokens",
+                type: "text",
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "text",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "ProfileImageUrl",
+                table: "AspNetUsers",
+                type: "character varying(255)",
+                maxLength: 255,
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "character varying(255)",
+                oldMaxLength: 255,
+                oldNullable: true);
+        }
+    }
+}

--- a/Flow Api/Models/Entities/User.cs
+++ b/Flow Api/Models/Entities/User.cs
@@ -10,7 +10,7 @@ namespace Flow_Api.Models.Entities
         public string Email { get; set; } = string.Empty;
         public string FirstName { get; set; } = string.Empty;
         public string LastName { get; set; } = string.Empty;
-        public string ProfileImageUrl { get; set; } = string.Empty;
+        public string? ProfileImageUrl { get; set; } = string.Empty;
         public bool IsActive { get; set; }
         public DateTime CreatedDate { get; set; }
         public DateTime? LastModifiedDate { get; set; }

--- a/Flow Api/Models/Identity/ApplicationUser.cs
+++ b/Flow Api/Models/Identity/ApplicationUser.cs
@@ -5,11 +5,11 @@ namespace Flow_Api.Models.Identity
 {
     public class ApplicationUser : IdentityUser
     {
-        public string FirstName { get; set; } = string.Empty;
-        public string LastName { get; set; } = string.Empty;
+        public string? FirstName { get; set; } = string.Empty;
+        public string? LastName { get; set; } = string.Empty;
         public string? ProfileImageUrl { get; set; }
         public bool IsActive { get; set; } = true;
-        public DateTime CreatedDate { get; set; } = DateTime.UtcNow;
-        public DateTime? LastModifiedDate { get; set; }
+        public DateTime? CreatedDate { get; set; } = DateTime.UtcNow;
+        public DateTime? LastModifiedDate { get; set; } = DateTime.UtcNow;
     }
 }

--- a/Flow Api/Services/Implementations/AuthService.cs
+++ b/Flow Api/Services/Implementations/AuthService.cs
@@ -88,13 +88,14 @@ namespace Flow_Api.Services.Implementations
                 AccessToken = accessToken,
                 RefreshToken = refreshToken,
                 Expiration = DateTime.UtcNow.AddMinutes(_jwtSettings.AccessTokenExpirationMinutes),
+                // ... inside LoginAsync, RegisterAsync, and RefreshTokenAsync where UserDto is constructed:
                 User = new UserDto
                 {
                     Id = user.Id,
                     UserName = user.UserName ?? string.Empty,
                     Email = user.Email ?? string.Empty,
-                    FirstName = user.FirstName,
-                    LastName = user.LastName,
+                    FirstName = user.FirstName ?? string.Empty,
+                    LastName = user.LastName ?? string.Empty,
                     ProfileImageUrl = user.ProfileImageUrl ?? string.Empty,
                     Roles = userRoles.ToList(),
                     Permissions = userPermissions.ToList()
@@ -219,13 +220,14 @@ namespace Flow_Api.Services.Implementations
                 AccessToken = newAccessToken,
                 RefreshToken = newRefreshToken,
                 Expiration = DateTime.UtcNow.AddMinutes(_jwtSettings.AccessTokenExpirationMinutes),
+                // ... inside LoginAsync, RegisterAsync, and RefreshTokenAsync where UserDto is constructed:
                 User = new UserDto
                 {
                     Id = user.Id,
                     UserName = user.UserName ?? string.Empty,
                     Email = user.Email ?? string.Empty,
-                    FirstName = user.FirstName,
-                    LastName = user.LastName,
+                    FirstName = user.FirstName ?? string.Empty,
+                    LastName = user.LastName ?? string.Empty,
                     ProfileImageUrl = user.ProfileImageUrl ?? string.Empty,
                     Roles = userRoles.ToList(),
                     Permissions = userPermissions.ToList()


### PR DESCRIPTION
This commit updates the `ProfileImageUrl` property in the `ApplicationUser` and `User` classes to be nullable, allowing users to have no associated profile image. The `OnModelCreating` method in `ApplicationDbContext.cs` has been modified accordingly, and migration files have been created to reflect these database changes.

Additionally, the `UserId` properties in the `UserOtps` and `RefreshTokens` tables are now nullable, indicating a change in user association handling. The `RateLimiterMiddleware` is updated to apply rate limiting only in production environments, and the `AuthService` class now safely handles potential null values for `FirstName` and `LastName` when constructing `UserDto` objects.

These changes enhance the application's robustness and flexibility in user data management.